### PR TITLE
Remove Kernel Source?

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -32,7 +32,7 @@ TARGET_2ND_CPU_ABI2 := armeabi
 TARGET_2ND_CPU_VARIANT := kryo
 
 # Kernel
-TARGET_KERNEL_SOURCE := kernel/razer/sdm845
+#TARGET_KERNEL_SOURCE := kernel/razer/sdm845
 TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_HEADER_ARCH := arm64
 TARGET_KERNEL_CONFIG := cheryl2-perf_defconfig


### PR DESCRIPTION
Since you're using a pre-built kernel, should this line be commented out?  I'm just trying to throw another set of eyes on it.  This line is commented out on the official cheryl twrp here: https://github.com/TeamWin/android_device_razer_cheryl/blob/android-7.1/BoardConfig.mk

Nvm, I see you made a commit to do this on purpose... I'm going to start from scratch and see if I can build TWRP.